### PR TITLE
fix: connected icon overlap on small screens (#9)

### DIFF
--- a/knx-web-app/frontend/src/index.css
+++ b/knx-web-app/frontend/src/index.css
@@ -1271,7 +1271,7 @@ html { overflow-x: hidden; }
   .status-badge {
     font-size: 0;    /* hide "Connected" text */
     padding: 0.35rem 0.5rem;
-    gap: 0;
+    gap: 4px;
   }
   .status-badge svg { display: block; }
 
@@ -1352,4 +1352,3 @@ html { overflow-x: hidden; }
   /* Modal */
   .modal-content { width: 96vw; padding: 1rem; }
 }
-


### PR DESCRIPTION
## Issue
Fixes #9 – On small/mobile screens the green status dot overlapped with the WiFi icon.

## Change
In the mobile media query, `.status-badge` `gap` was changed from `0` to `4px` so the dot has proper breathing room from the icon.

**File changed:** `knx-web-app/frontend/src/index.css`

## Test Link
🔗 https://affair-thats-participate-simulations.trycloudflare.com

> Note: Open on a small/mobile screen to see the fix. The status indicator is in the top-right navigation bar.