### PR TITLE
fix: Generate Base Scenes only adds Off and Bright (closes #16)

### DIFF
--- a/knx-web-app/frontend/src/Settings.jsx
+++ b/knx-web-app/frontend/src/Settings.jsx
@@ -543,9 +543,7 @@ export default function Settings({ config, fetchConfig, addToast, hueStatus, set
     const toAdd = [];
     if (!used.includes(1)) toAdd.push({ id: Date.now() + '_1', name: 'Off', sceneNumber: 1, category: 'light' });
     if (!used.includes(2)) toAdd.push({ id: Date.now() + '_2', name: 'Bright', sceneNumber: 2, category: 'light' });
-    if (!used.includes(3)) toAdd.push({ id: Date.now() + '_3', name: 'Shades Up', sceneNumber: 3, category: 'shade' });
-    if (!used.includes(4)) toAdd.push({ id: Date.now() + '_4', name: 'Shades Down', sceneNumber: 4, category: 'shade' });
-    if (!toAdd.length) { addToast('Base numbers 1-4 already exist', 'success'); return; }
+    if (!toAdd.length) { addToast('Base scenes Off and Bright already exist', 'success'); return; }
     updateRoom(roomId, { scenes: [...existing, ...toAdd] });
     addToast(`Added ${toAdd.map(s => s.name).join(' & ')}`, 'success');
   };


### PR DESCRIPTION
Fixes #16 – "Generate Base Scenes" erzeugt jetzt nur noch die Licht-Szenen Off (1) und Bright (2), keine Shade-Szenen mehr.

-Claude