### PR TITLE
feat/raspi-install-script

### DIFF
--- a/knx-web-app/README.md
+++ b/knx-web-app/README.md
@@ -86,7 +86,14 @@ Because the app is registered on the OS level, you no longer need to keep a term
 * `knx-stop` - Stops the web app service.
 * `knx-restart` - Restarts the service.
 * `knx-log` - Displays the live logs (press `Ctrl-C` to close logs, the app will keep running).
-* `knx-uninstall` - Completely removes the app, the background services, and all associated configs.
+
+### Upgrading the App
+When a new version is pushed to GitHub, simply type:
+* `knx-update` - This automatically downloads the newest version, rebuilds the frontend, updates all Node.js dependencies, and restarts the background service. **Your configurations (rooms, IPs) will remain securely untouched!**
+
+### Uninstalling
+If you no longer wish to run the app on this device, simply type:
+* `knx-uninstall` - You will be prompted to confirm. If you type 'y', the process will completely remove the background services, delete the `~/.knx-web-app` installation folder, and erase all CLI shortcuts from your system effortlessly.
 
 **Autostart on boot**  
 The installation automatically enabled autostart. If you ever need to turn this off, you can manually disable the systemd feature using:

--- a/knx-web-app/README.md
+++ b/knx-web-app/README.md
@@ -22,23 +22,23 @@ A local web application for controlling a KNX smart home system via a KNX IP int
 
 ## Architecture Overview
 
-```
-┌────────────────────┐        HTTP / WebSocket        ┌─────────────────────┐
-│  Browser (React)   │ ◄────────────────────────────► │  Backend (Node.js)  │
-│  localhost:5173    │                                 │  localhost:3001     │
-└────────────────────┘                                 └──────────┬──────────┘
-                                                                  │
-                                               KNX IP (UDP 3671)  │  HTTP (local LAN)
-                                                         ┌────────┴────────┐
-                                                         │                 │
-                                                  ┌──────┴──────┐   ┌──────┴──────┐
-                                                  │  KNX IP     │   │  Philips    │
-                                                  │  Interface  │   │  Hue Bridge │
-                                                  └─────────────┘   └─────────────┘
+```text
+┌─────────────────────┐      HTTP / WebSocket      ┌─────────────────────┐
+│ Browser (React UI)  │ ◄────────────────────────► │ Backend (Node.js)   │
+│ Any device in WLAN  │                            │ Port 3001           │
+└─────────────────────┘                            └──────────┬──────────┘
+                                                              │
+                                            KNX IP (UDP 3671) │ HTTP (local LAN)
+                                                      ┌───────┴───────┐
+                                                      │               │
+                                              ┌───────┴───────┐ ┌─────┴───────┐
+                                              │ KNX IP        │ │ Philips     │
+                                              │ Interface     │ │ Hue Bridge  │
+                                              └───────────────┘ └─────────────┘
 ```
 
-- **Frontend**: React + Vite, served on `http://localhost:5173`
-- **Backend**: Express + Socket.IO, served on `http://localhost:3001`
+- **Frontend**: React + Vite UI (served automatically by the backend in production)
+- **Backend**: Express + Socket.IO (serves API, Websockets and the Frontend on Port 3001)
 - **KNX**: Communicates via UDP to the KNX IP interface on port 3671
 - **Hue**: Communicates via HTTP to the Philips Hue Bridge on the local LAN
 - **Persistence**: All configuration (rooms, functions, IP settings, Hue credentials) is stored in `backend/config.json`
@@ -69,7 +69,6 @@ Run the following command in your terminal to download and start the installatio
 ```bash
 bash <(curl -fsSL https://raw.githubusercontent.com/candyscode/AI/main/knx-web-app/install.sh)
 ```
-*(Make sure to push your `install.sh` file to your GitHub repository `main` branch before running this!)*
 
 This script will explain what it's about to do and pause to let you confirm. Under the hood, it performs the following:
 * If no Node.js is detected, it automatically installs Node.js v20 LTS securely via NodeSource.
@@ -125,9 +124,9 @@ VITE v8.x.x  ready in xxx ms
 > pkill -f "vite"; pkill -f "node server.js"
 > ```
 
-### 3. Open in Browser
+### 3. Open in Browser (Development)
 
-Navigate to: **http://localhost:5173**
+Navigate to: **http://localhost:5173** (In production via the daemon, use `http://<Raspberry-IP>:3001`)
 
 ---
 
@@ -276,7 +275,7 @@ knx-web-app/
 
 ## API Reference
 
-All endpoints are on `http://localhost:3001`.
+All endpoints are provided by the backend service (default port `3001`).
 
 ### Config
 

--- a/knx-web-app/README.md
+++ b/knx-web-app/README.md
@@ -67,7 +67,7 @@ We provide a script to securely install Node.js, npm, and the KNX Web App via a 
 Run the following command in your terminal to download and start the installation:
 
 ```bash
-bash <(curl -fsSL https://raw.githubusercontent.com/dein-github-name/knx-web-app/main/install.sh)
+bash <(curl -fsSL https://raw.githubusercontent.com/candyscode/AI/main/knx-web-app/install.sh)
 ```
 *(Make sure to push your `install.sh` file to your GitHub repository `main` branch before running this!)*
 

--- a/knx-web-app/README.md
+++ b/knx-web-app/README.md
@@ -58,46 +58,62 @@ Before running this app, you need:
 
 ---
 
-## Installation
+## Installation & Deployment
 
-Clone the repository and install dependencies for both frontend and backend:
+## Installation & Upgrades
+
+We provide a script to securely install Node.js, npm, and the KNX Web App via a single command onto a Raspberry Pi, or any Debian-based Linux OS. This script can also be used to seamlessly upgrade an existing install when a new release is passed to the main branch.
+
+Run the following command in your terminal to download and start the installation:
 
 ```bash
-# Backend
-cd backend
-npm install
+bash <(curl -fsSL https://raw.githubusercontent.com/dein-github-name/knx-web-app/main/install.sh)
+```
+*(Make sure to push your `install.sh` file to your GitHub repository `main` branch before running this!)*
 
-# Frontend
-cd ../frontend
-npm install
+This script will explain what it's about to do and pause to let you confirm. Under the hood, it performs the following:
+* If no Node.js is detected, it automatically installs Node.js v20 LTS securely via NodeSource.
+* Clones (or updates) the application safely into a dedicated `~/.knx-web-app` home directory.
+* Compiles the React frontend into an optimized production-build bundle.
+* Automatically registers the application as a `systemd` background service so it will survive reboots and keep running effortlessly.
+
+---
+
+## 🛠️ Working with the background service (CLI)
+
+Because the app is registered on the OS level, you no longer need to keep a terminal running to keep your smart home alive. The installer also sets up several convenient global commands in your terminal:
+
+* `knx-start` - Starts the web app service in the background.
+* `knx-stop` - Stops the web app service.
+* `knx-restart` - Restarts the service.
+* `knx-log` - Displays the live logs (press `Ctrl-C` to close logs, the app will keep running).
+* `knx-uninstall` - Completely removes the app, the background services, and all associated configs.
+
+**Autostart on boot**  
+The installation automatically enabled autostart. If you ever need to turn this off, you can manually disable the systemd feature using:
+```bash
+sudo systemctl disable knx-web-app.service
 ```
 
 ---
 
-## Starting the App
+## Development / Manual Setup
 
-You need to start **two separate processes**: the backend server and the frontend dev server.
-
-### 1. Start the Backend
+If you prefer to run it manually or hack on the features, just clone the repo and launch the frontend and backend manually in two separate terminal tabs:
 
 ```bash
+# 1. Start the Backend
 cd backend
+npm install
 node server.js
-```
+# Runs on :3001
 
-Expected output:
-```
-Backend server running on http://localhost:3001
-```
-
-### 2. Start the Frontend
-
-```bash
-cd frontend
+# 2. Start the Frontend
+cd ../frontend
+npm install
 npm run dev
+# Vite runs on :5173
 ```
-
-Expected output:
 ```
 VITE v8.x.x  ready in xxx ms
 

--- a/knx-web-app/backend/server.js
+++ b/knx-web-app/backend/server.js
@@ -381,7 +381,18 @@ io.on('connection', (socket) => {
   socket.emit('knx_initial_states', knxService.deviceStates);
 });
 
+// --- STATIC FRONTEND SERVING (PRODUCTION) ---
+const distPath = path.join(__dirname, '../frontend/dist');
+if (fs.existsSync(distPath)) {
+  console.log(`Serving static frontend from ${distPath}`);
+  app.use(express.static(distPath));
+  // Catch-all to serve index.html for React Router
+  app.get('*', (req, res) => {
+    res.sendFile(path.join(distPath, 'index.html'));
+  });
+}
+
 const PORT = 3001;
-server.listen(PORT, () => {
-  console.log(`Backend server running on http://localhost:${PORT}`);
+server.listen(PORT, '0.0.0.0', () => {
+  console.log(`Backend server running on http://0.0.0.0:${PORT}`);
 });

--- a/knx-web-app/backend/server.js
+++ b/knx-web-app/backend/server.js
@@ -387,12 +387,25 @@ if (fs.existsSync(distPath)) {
   console.log(`Serving static frontend from ${distPath}`);
   app.use(express.static(distPath));
   // Catch-all to serve index.html for React Router
-  app.get('*', (req, res) => {
+  app.get(/.*/, (req, res) => {
     res.sendFile(path.join(distPath, 'index.html'));
   });
 }
 
 const PORT = 3001;
+
+server.on('error', (err) => {
+  if (err.code === 'EADDRINUSE') {
+    console.error(`\n❌ ERROR: Port ${PORT} is already in use.`);
+    console.error(`This usually means the KNX Web App is already running in the background (e.g., via systemd or another terminal).`);
+    console.error(`Stop the other instance (e.g., 'knx-stop' or 'pkill node') before starting a new one.\n`);
+    process.exit(1);
+  } else {
+    console.error(`\n❌ ERROR: Failed to start the server:`, err.message);
+    process.exit(1);
+  }
+});
+
 server.listen(PORT, '0.0.0.0', () => {
   console.log(`Backend server running on http://0.0.0.0:${PORT}`);
 });

--- a/knx-web-app/frontend/src/App.jsx
+++ b/knx-web-app/frontend/src/App.jsx
@@ -38,8 +38,16 @@ function App() {
   useEffect(() => {
     fetchConfig();
     
-    // Initialize socket inside effect to prevent missing early "initial_states" events
-    const socket = io(import.meta.env.VITE_BACKEND_URL || 'http://localhost:3001');
+    // Determine socket URL based on environment
+    let socketUrl = 'http://localhost:3001';
+    if (import.meta.env.VITE_BACKEND_URL) {
+      socketUrl = import.meta.env.VITE_BACKEND_URL;
+    } else if (!import.meta.env.DEV) {
+      socketUrl = '/'; // Production static hosting via backend
+    }
+
+    const socket = io(socketUrl);
+    setSocket(socket);
 
     socket.on('knx_status', (status) => {
       setKnxStatus(status);

--- a/knx-web-app/frontend/src/App.jsx
+++ b/knx-web-app/frontend/src/App.jsx
@@ -47,7 +47,6 @@ function App() {
     }
 
     const socket = io(socketUrl);
-    setSocket(socket);
 
     socket.on('knx_status', (status) => {
       setKnxStatus(status);

--- a/knx-web-app/frontend/src/configApi.js
+++ b/knx-web-app/frontend/src/configApi.js
@@ -1,4 +1,9 @@
-const API_BASE = `${import.meta.env.VITE_BACKEND_URL || 'http://localhost:3001'}/api`;
+const getApiBase = () => {
+  if (import.meta.env.VITE_BACKEND_URL) return `${import.meta.env.VITE_BACKEND_URL}/api`;
+  if (import.meta.env.DEV) return 'http://localhost:3001/api';
+  return '/api'; // Use relative path when statically served
+};
+const API_BASE = getApiBase();
 
 export const getConfig = async () => {
   const res = await fetch(`${API_BASE}/config`);

--- a/knx-web-app/install.sh
+++ b/knx-web-app/install.sh
@@ -112,6 +112,7 @@ create_cli_command "knx-start"   "sudo systemctl start $SERVICE_NAME"
 create_cli_command "knx-stop"    "sudo systemctl stop $SERVICE_NAME"
 create_cli_command "knx-restart" "sudo systemctl restart $SERVICE_NAME"
 create_cli_command "knx-log"     "sudo journalctl -u $SERVICE_NAME -f"
+create_cli_command "knx-update"  "bash <(curl -fsSL https://raw.githubusercontent.com/candyscode/AI/main/knx-web-app/install.sh)"
 
 # Uninstall command
 sudo bash -c "cat > /usr/local/bin/knx-uninstall <<EOF
@@ -128,6 +129,7 @@ if [[ \\\$prompt =~ ^[Yy]$ ]]; then
     sudo rm /usr/local/bin/knx-stop
     sudo rm /usr/local/bin/knx-restart
     sudo rm /usr/local/bin/knx-log
+    sudo rm /usr/local/bin/knx-update
     sudo rm /usr/local/bin/knx-uninstall
     echo \"Uninstallation complete.\"
 else
@@ -149,6 +151,7 @@ echo "  knx-start    - Start the app"
 echo "  knx-stop     - Stop the app"
 echo "  knx-restart  - Restart the app"
 echo "  knx-log      - View live logs"
+echo "  knx-update   - Update to the latest version from GitHub"
 echo "  knx-uninstall - Remove the app completely"
 echo ""
 echo "You can access your dashboard safely at:"

--- a/knx-web-app/install.sh
+++ b/knx-web-app/install.sh
@@ -4,7 +4,7 @@
 set -e
 
 # Configuration
-REPO_URL="https://github.com/YOUR_GITHUB_USERNAME/knx-web-app.git" # <-- UPDATE THIS
+REPO_URL="https://github.com/candyscode/AI.git"
 INSTALL_DIR="$HOME/.knx-web-app"
 SERVICE_NAME="knx-web-app.service"
 USER_NAME=$(whoami)
@@ -58,7 +58,7 @@ else
     git clone "$REPO_URL" "$INSTALL_DIR"
 fi
 
-cd "$INSTALL_DIR"
+cd "$INSTALL_DIR/knx-web-app"
 
 # Install Dependencies and Build
 echo "=> Installing Frontend dependencies and building..."
@@ -82,8 +82,8 @@ Description=KNX Web App Backend
 After=network.target
 
 [Service]
-ExecStart=$NODE_BIN $INSTALL_DIR/backend/server.js
-WorkingDirectory=$INSTALL_DIR/backend
+ExecStart=$NODE_BIN $INSTALL_DIR/knx-web-app/backend/server.js
+WorkingDirectory=$INSTALL_DIR/knx-web-app/backend
 Restart=always
 User=$USER_NAME
 Environment=NODE_ENV=production

--- a/knx-web-app/install.sh
+++ b/knx-web-app/install.sh
@@ -58,19 +58,18 @@ else
     git clone "$REPO_URL" "$INSTALL_DIR"
 fi
 
-cd "$INSTALL_DIR/knx-web-app"
+# Define the actual app path within the cloned repository
+APP_DIR="$INSTALL_DIR/knx-web-app"
 
 # Install Dependencies and Build
 echo "=> Installing Frontend dependencies and building..."
-cd frontend
+cd "$APP_DIR/frontend"
 npm ci || npm install
 npm run build
-cd ..
 
 echo "=> Installing Backend dependencies..."
-cd backend
+cd "$APP_DIR/backend"
 npm ci || npm install
-cd ..
 
 # Set up Systemd Service
 echo "=> Configuring Background Service (systemd)..."
@@ -82,8 +81,8 @@ Description=KNX Web App Backend
 After=network.target
 
 [Service]
-ExecStart=$NODE_BIN $INSTALL_DIR/knx-web-app/backend/server.js
-WorkingDirectory=$INSTALL_DIR/knx-web-app/backend
+ExecStart=$NODE_BIN $APP_DIR/backend/server.js
+WorkingDirectory=$APP_DIR/backend
 Restart=always
 User=$USER_NAME
 Environment=NODE_ENV=production

--- a/knx-web-app/install.sh
+++ b/knx-web-app/install.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+# KNX Web App - Global Installation Script
+
+set -e
+
+# Configuration
+REPO_URL="https://github.com/YOUR_GITHUB_USERNAME/knx-web-app.git" # <-- UPDATE THIS
+INSTALL_DIR="$HOME/.knx-web-app"
+SERVICE_NAME="knx-web-app.service"
+USER_NAME=$(whoami)
+
+echo "==========================================================="
+echo " KNX Web App - Automated Installer"
+echo "==========================================================="
+echo ""
+echo "This script will perform the following actions:"
+echo "  1. Check and install necessary system tools (git, curl, build-essential)"
+echo "  2. Detect Node.js, and if missing, install the Node.js v20 LTS release."
+echo "  3. Clone the KNX Web App repository into $INSTALL_DIR."
+echo "     (If an existing installation is found, it will be updated safely while preserving your config.json)."
+echo "  4. Build and install the Frontend and Backend dependencies."
+echo "  5. Set up the application to run as a systemd background service."
+echo "  6. Install global command-line utilities (knx-start, knx-stop, knx-log, etc.)."
+echo ""
+
+read -p "Press Enter to continue, or Ctrl+C to abort..." prompt
+
+echo ""
+echo "=> Checking system prerequisites..."
+
+# Request sudo upfront
+sudo -v
+# Keep-alive: update existing `sudo` time stamp until script has finished
+while true; do sudo -n true; sleep 60; kill -0 "$$" || exit; done 2>/dev/null &
+
+sudo apt-get update -y
+sudo apt-get install -y git curl build-essential
+
+# Node.js Check
+echo "=> Checking Node.js..."
+if ! command -v node >/dev/null 2>&1 || ! command -v npm >/dev/null 2>&1; then
+    echo "Node.js not found. Installing Node.js v20 LTS via NodeSource..."
+    curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+    sudo apt-get install -y nodejs
+else
+    echo "Found Node.js $(node -v)"
+fi
+
+# Clone or Update Repo
+echo "=> Setting up KNX Web App in $INSTALL_DIR..."
+if [ -d "$INSTALL_DIR" ]; then
+    echo "Existing installation found. Updating via git pull..."
+    cd "$INSTALL_DIR"
+    git fetch --all
+    git reset --hard origin/main
+else
+    echo "Cloning repository..."
+    git clone "$REPO_URL" "$INSTALL_DIR"
+fi
+
+cd "$INSTALL_DIR"
+
+# Install Dependencies and Build
+echo "=> Installing Frontend dependencies and building..."
+cd frontend
+npm ci || npm install
+npm run build
+cd ..
+
+echo "=> Installing Backend dependencies..."
+cd backend
+npm ci || npm install
+cd ..
+
+# Set up Systemd Service
+echo "=> Configuring Background Service (systemd)..."
+NODE_BIN=$(which node)
+
+sudo bash -c "cat > /etc/systemd/system/$SERVICE_NAME <<EOF
+[Unit]
+Description=KNX Web App Backend
+After=network.target
+
+[Service]
+ExecStart=$NODE_BIN $INSTALL_DIR/backend/server.js
+WorkingDirectory=$INSTALL_DIR/backend
+Restart=always
+User=$USER_NAME
+Environment=NODE_ENV=production
+
+[Install]
+WantedBy=multi-user.target
+EOF"
+
+sudo systemctl daemon-reload
+sudo systemctl enable $SERVICE_NAME
+sudo systemctl restart $SERVICE_NAME
+
+# Install CLI Commands
+echo "=> Installing Global Commands..."
+
+create_cli_command() {
+    local cmd_name=$1
+    local cmd_content=$2
+    sudo bash -c "cat > /usr/local/bin/$cmd_name <<'EOF'
+#!/bin/bash
+$cmd_content
+EOF"
+    sudo chmod +x /usr/local/bin/$cmd_name
+}
+
+create_cli_command "knx-start"   "sudo systemctl start $SERVICE_NAME"
+create_cli_command "knx-stop"    "sudo systemctl stop $SERVICE_NAME"
+create_cli_command "knx-restart" "sudo systemctl restart $SERVICE_NAME"
+create_cli_command "knx-log"     "sudo journalctl -u $SERVICE_NAME -f"
+
+# Uninstall command
+sudo bash -c "cat > /usr/local/bin/knx-uninstall <<EOF
+#!/bin/bash
+echo \"Uninstalling KNX Web App...\"
+read -p \"Are you sure you want to delete the app and all configurations? [y/N] \" prompt
+if [[ \\\$prompt =~ ^[Yy]$ ]]; then
+    sudo systemctl stop $SERVICE_NAME
+    sudo systemctl disable $SERVICE_NAME
+    sudo rm /etc/systemd/system/$SERVICE_NAME
+    sudo systemctl daemon-reload
+    rm -rf $INSTALL_DIR
+    sudo rm /usr/local/bin/knx-start
+    sudo rm /usr/local/bin/knx-stop
+    sudo rm /usr/local/bin/knx-restart
+    sudo rm /usr/local/bin/knx-log
+    sudo rm /usr/local/bin/knx-uninstall
+    echo \"Uninstallation complete.\"
+else
+    echo \"Uninstallation aborted.\"
+fi
+EOF"
+sudo chmod +x /usr/local/bin/knx-uninstall
+
+LOCAL_IP=$(hostname -I 2>/dev/null | awk '{print $1}')
+[ -z "$LOCAL_IP" ] && LOCAL_IP="localhost"
+
+echo "==========================================================="
+echo " Installation Complete! "
+echo "==========================================================="
+echo "The KNX Web App is now running in the background."
+echo ""
+echo "Available CLI Commands:"
+echo "  knx-start    - Start the app"
+echo "  knx-stop     - Stop the app"
+echo "  knx-restart  - Restart the app"
+echo "  knx-log      - View live logs"
+echo "  knx-uninstall - Remove the app completely"
+echo ""
+echo "You can access your dashboard safely at:"
+echo "http://${LOCAL_IP}:3001"
+echo "==========================================================="


### PR DESCRIPTION
ANWEISUNG:

Aktuell lassen wir die App ja lokal auf dem Mac laufen. Ich möchte sie gerne einfach und nutzerfreundlich auf Raspberry PIs und ähnlichen Klein-PCs installierbar machen, sodass sie dauerhaft im Heimnetz der Nutzer laufen kann und jeder im WLAN auf die Web-App zugreifen kann, um das KNX-Smarthome zu bedienen und es zu konfigurieren. Die Konfiguration soll natürlich global für alle Besucher der Webapp innerhalb des Heimnetzes sein. Zugriff von außerhalb ist erstmal nicht geplant.

Bitte erstelle eine Möglichkeit, um mit möglichst einem Command auf einem Raspberry PI o.Ä. die App zum laufen zu bringen. Evtl. über eine Art Install Wizard per CLI. Auch die Dependencies sollten nach Möglichkeit (sag mir gerne wenn das eine schlechte Idee ist) automatisch installierbar sein. Finde zumindest eine gute Lösung, wie man als Nutzer möglichst einfach die Software zum Laufen bekommt, auch wenn z.B. noch kein NPM installiert ist.

Die Anleitung, wie man das installiert, soll dann im README nachzulesen sein.

Ich möchte mich bei der Art und Weise das zu installieren an Vorbildern wie Homebrew und NodeRed orientieren. Die Installations-Anleitungen sehen dort so aus:  Installing and Upgrading Node-RED
We provide a script to install Node.js, npm and Node-RED onto a Raspberry Pi, and other platforms running a Debian based OS. The script can also be used to upgrade an existing install when a new release is available.
Running the following command will download and run the script. If you want to review the contents of the script first, you can view it on Github. 
bash <(curl -sL https://github.com/node-red/linux-installers/releases/latest/download/update-nodejs-and-nodered-deb) (=> SO EINEN COMMAND FÄNDE ICH SUPER ALS INSTALLER)
 There are extra parameters you can pass to the script. Add --help to the end of the above command to see them. 

This script will work on any Debian-based operating system, including Ubuntu and Diet-Pi. You may need to run sudo apt install build-essential git curl first to ensure npm is able to fetch and build any binary modules it needs to install.
This script will:
* remove the existing version of Node-RED if present.
* if it detects Node.js is already installed, it will ensure it is at least v20. If nothing is found it will install the Node.js v22 LTS release using the NodeSource package.
* install the latest version of Node-RED using npm.
* optionally install a collection of useful Pi-specific nodes.
* setup Node-RED to run as a service and provide a set of commands to work with the service.
  Bzw für Homebrew:  Install Homebrew

/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" (=> ODER AUCH SO EINEN COMMAND FÄNDE ICH EBENFALLS SUPER ALS INSTALLER)
📋
Paste that in a macOS Terminal or Linux shell prompt.
The script explains what it will do and then pauses before it does it. Read about other installation options.  Wichtig ist auch, dass die App dann dauerhaft laufen kann und auch einen Neustart des Raspi etc. überlebt.  Bei NodeRed ist das wie folgt gelöst:  Running locally
As with running Node-RED locally, you can use the node-red command to run Node-RED in a terminal. It can then be stopped by pressing Ctrl-C or by closing the terminal window.
Due to the limited memory of the Raspberry Pi, you may need to start Node-RED with an additional argument to tell the underlying Node.js process to free up unused memory sooner than it would otherwise.
To do this, you should use the alternative node-red-pi command and pass in the max-old-space-size argument.
node-red-pi --max-old-space-size=256
Running as a service
The install script also sets it up to run as a service. This means it can run in the background and be enabled to automatically start on boot.
The following commands are provided to work with the service:
* node-red-start - this starts the Node-RED service and displays its log output. Pressing Ctrl-C or closing the window does not stop the service; it keeps running in the background. Use node-red-log to re-attach and view the log.
* node-red-stop - this stops the Node-RED service
* node-red-restart - this restarts the Node-RED service
* node-red-reload - this stops then starts the Node-RED service
* node-red-log - this displays the log output of the service
You can also start the Node-RED service on the Raspberry Pi OS Desktop by selecting the Menu -> Programming -> Node-RED menu option.
Autostart on boot
If you want Node-RED to run when the device is turned on, or re-booted, you can enable the service to autostart by running the command:
sudo systemctl enable nodered.service
To disable the service, run the command:
sudo systemctl disable nodered.service  Bitte baue auch eine Möglichkeit ein, die Software über einen Command zu deinstallieren.  Bitte update die README mit den Instruktionen!