### PR TITLE
fix/42-persist-imported-ets-xml-data

### DIFF
--- a/knx-web-app/backend/server.js
+++ b/knx-web-app/backend/server.js
@@ -17,7 +17,15 @@ const io = new Server(server, {
 app.use(cors());
 app.use(bodyParser.json());
 
-const CONFIG_FILE = path.join(__dirname, 'config.json');
+const DEFAULT_PORT = 3001;
+const PORT = parseInt(process.env.PORT, 10) || DEFAULT_PORT;
+const HOST = process.env.HOST || '0.0.0.0';
+const configDir = process.env.KNX_CONFIG_DIR
+  ? path.resolve(process.env.KNX_CONFIG_DIR)
+  : __dirname;
+const CONFIG_FILE = process.env.KNX_CONFIG_FILE
+  ? path.resolve(process.env.KNX_CONFIG_FILE)
+  : path.join(configDir, 'config.json');
 
 const knxService = new KnxService(io);
 const hueService = new HueService();
@@ -27,8 +35,35 @@ let config = {
   knxIp: '',
   knxPort: 3671,
   hue: { bridgeIp: '', apiKey: '' },
-  rooms: []
+  rooms: [],
+  importedGroupAddresses: [],
+  importedGroupAddressesFileName: ''
 };
+
+function normalizeImportedGroupAddresses(addresses) {
+  if (!Array.isArray(addresses)) return [];
+  return addresses
+    .filter((entry) => entry && typeof entry === 'object')
+    .map((entry) => ({
+      address: typeof entry.address === 'string' ? entry.address : '',
+      name: typeof entry.name === 'string' ? entry.name : '',
+      dpt: typeof entry.dpt === 'string' ? entry.dpt : '',
+      functionType: typeof entry.functionType === 'string' ? entry.functionType : '',
+      supported: entry.supported !== false,
+    }))
+    .filter((entry) => entry.address && entry.name);
+}
+
+function normalizeConfigShape(input) {
+  if (!input || typeof input !== 'object') return;
+  if (!input.knxPort) input.knxPort = 3671;
+  if (!input.hue) input.hue = { bridgeIp: '', apiKey: '' };
+  if (!Array.isArray(input.rooms)) input.rooms = [];
+  input.importedGroupAddresses = normalizeImportedGroupAddresses(input.importedGroupAddresses);
+  input.importedGroupAddressesFileName = typeof input.importedGroupAddressesFileName === 'string'
+    ? input.importedGroupAddressesFileName
+    : '';
+}
 
 function establishConnection() {
   if (config.knxIp) {
@@ -80,13 +115,16 @@ async function handleExternalSceneTrigger(groupAddress, sceneNumber) {
   await triggerLinkedHueScene(groupAddress, sceneNumber);
 }
 
+function ensureConfigDir() {
+  fs.mkdirSync(path.dirname(CONFIG_FILE), { recursive: true });
+}
+
 // Load config
 if (fs.existsSync(CONFIG_FILE)) {
   try {
     const data = fs.readFileSync(CONFIG_FILE, 'utf8');
     config = JSON.parse(data);
-    if (!config.knxPort) config.knxPort = 3671;
-    if (!config.hue) config.hue = { bridgeIp: '', apiKey: '' };
+    normalizeConfigShape(config);
     hueService.init(config.hue);
     establishConnection();
   } catch(e) {
@@ -95,7 +133,10 @@ if (fs.existsSync(CONFIG_FILE)) {
 }
 
 function saveConfig() {
-  fs.writeFileSync(CONFIG_FILE, JSON.stringify(config, null, 2));
+  ensureConfigDir();
+  const tempFile = `${CONFIG_FILE}.tmp`;
+  fs.writeFileSync(tempFile, JSON.stringify(config, null, 2));
+  fs.renameSync(tempFile, CONFIG_FILE);
 }
 
 // Ensure the local file exists right away
@@ -130,7 +171,18 @@ app.post('/api/config', (req, res) => {
   if (rooms !== undefined) {
     config.rooms = rooms;
   }
+
+  if (req.body.importedGroupAddresses !== undefined) {
+    config.importedGroupAddresses = normalizeImportedGroupAddresses(req.body.importedGroupAddresses);
+  }
+
+  if (req.body.importedGroupAddressesFileName !== undefined) {
+    config.importedGroupAddressesFileName = typeof req.body.importedGroupAddressesFileName === 'string'
+      ? req.body.importedGroupAddressesFileName
+      : '';
+  }
   
+  normalizeConfigShape(config);
   saveConfig();
   res.json({ success: true, config });
 });
@@ -142,6 +194,7 @@ app.post('/api/dev/load-config', (req, res) => {
     try {
       const data = fs.readFileSync(DEV_CONFIG_FILE, 'utf8');
       config = JSON.parse(data);
+      normalizeConfigShape(config);
       saveConfig();
       if (config.knxIp) {
         establishConnection();
@@ -392,20 +445,18 @@ if (fs.existsSync(distPath)) {
   });
 }
 
-const PORT = 3001;
-
 server.on('error', (err) => {
   if (err.code === 'EADDRINUSE') {
     console.error(`\n❌ ERROR: Port ${PORT} is already in use.`);
-    console.error(`This usually means the KNX Web App is already running in the background (e.g., via systemd or another terminal).`);
-    console.error(`Stop the other instance (e.g., 'knx-stop' or 'pkill node') before starting a new one.\n`);
-    process.exit(1);
-  } else {
-    console.error(`\n❌ ERROR: Failed to start the server:`, err.message);
+    console.error(`This usually means the KNX Web App is already running in the background.`);
     process.exit(1);
   }
+
+  console.error(`\n❌ ERROR: Failed to start the server:`, err.message);
+  process.exit(1);
 });
 
-server.listen(PORT, '0.0.0.0', () => {
-  console.log(`Backend server running on http://0.0.0.0:${PORT}`);
+server.listen(PORT, HOST, () => {
+  console.log(`Backend server running on http://${HOST}:${PORT}`);
+  console.log(`Using config file at ${CONFIG_FILE}`);
 });

--- a/knx-web-app/frontend/src/Settings.jsx
+++ b/knx-web-app/frontend/src/Settings.jsx
@@ -600,6 +600,8 @@ export default function Settings({ config, fetchConfig, addToast, hueStatus, set
     setPort(config.knxPort || 3671);
     setRooms(migrateRooms(config.rooms || []));
     setHueBridgeIp(config.hue?.bridgeIp || '');
+    setGroupAddressBook(Array.isArray(config.importedGroupAddresses) ? config.importedGroupAddresses : []);
+    setGroupAddressFileName(config.importedGroupAddressesFileName || '');
   }, [config]);
   // Hue scene linking modal
   const [hueSceneModal, setHueSceneModal] = useState({ open: false, roomId: null, sceneId: null });
@@ -829,16 +831,31 @@ export default function Settings({ config, fetchConfig, addToast, hueStatus, set
     setGroupAddressModal({ open: false, roomId: null, title: 'Select Group Address', mode: 'any', target: null, allowUpload: false, helperText: '' });
   };
 
-  const importGroupAddresses = (addresses, fileName) => {
-    setGroupAddressBook(addresses);
-    setGroupAddressFileName(fileName);
-    addToast(`Imported ${addresses.length} group addresses`, 'success');
+  const importGroupAddresses = async (addresses, fileName) => {
+    try {
+      await updateConfig({
+        importedGroupAddresses: addresses,
+        importedGroupAddressesFileName: fileName,
+      });
+      setGroupAddressBook(addresses);
+      setGroupAddressFileName(fileName);
+      addToast(`Imported ${addresses.length} group addresses`, 'success');
+      fetchConfig();
+    } catch {
+      addToast('Failed to persist imported group addresses', 'error');
+    }
   };
 
-  const clearGroupAddresses = () => {
-    setGroupAddressBook([]);
-    setGroupAddressFileName('');
-    addToast('Imported group addresses cleared', 'success');
+  const clearGroupAddresses = async () => {
+    try {
+      await updateConfig({ importedGroupAddresses: [], importedGroupAddressesFileName: '' });
+      setGroupAddressBook([]);
+      setGroupAddressFileName('');
+      addToast('Imported group addresses cleared', 'success');
+      fetchConfig();
+    } catch {
+      addToast('Failed to clear imported group addresses', 'error');
+    }
   };
 
   const handleSelectGroupAddress = async (groupAddress) => {

--- a/knx-web-app/frontend/src/__tests__/Settings.test.jsx
+++ b/knx-web-app/frontend/src/__tests__/Settings.test.jsx
@@ -30,6 +30,8 @@ const BASE_CONFIG = {
   knxPort: 3671,
   hue: { bridgeIp: '', apiKey: '' },
   rooms: [],
+  importedGroupAddresses: [],
+  importedGroupAddressesFileName: '',
 };
 
 const CONFIG_WITH_ROOM = {
@@ -363,6 +365,58 @@ describe('Settings — ETS modal filtering', () => {
       });
 
       expect(addToast).toHaveBeenCalledWith('Added "Living Room - Blind Position" from ETS', 'success');
+    } finally {
+      window.FileReader = originalFileReader;
+    }
+  });
+
+  it('persists imported ETS addresses in config so they survive backend restarts', async () => {
+    const user = userEvent.setup();
+    renderSettings(CONFIG_WITH_ROOM);
+
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+      <KNX>
+        <GroupAddresses>
+          <GroupRange Name="House">
+            <GroupRange Name="Hallway">
+              <GroupAddress Id="ga-1" Address="1/0/1" Name="Hallway Light" DPTs="DPT 1.001" />
+            </GroupRange>
+          </GroupRange>
+        </GroupAddresses>
+      </KNX>`;
+
+    const originalFileReader = window.FileReader;
+    class MockFileReader {
+      constructor() {
+        this.onload = null;
+        this.onerror = null;
+      }
+      readAsText() {
+        this.onload?.({ target: { result: xml } });
+      }
+    }
+    window.FileReader = MockFileReader;
+
+    try {
+      await user.click(screen.getByRole('button', { name: /manage imported ets xml/i }));
+
+      const fileInput = document.querySelector('input[type="file"]');
+      expect(fileInput).not.toBeNull();
+      fireEvent.change(fileInput, { target: { files: [new File([xml], 'ets-export.xml', { type: 'text/xml' })] } });
+
+      expect(await screen.findByText(/imported 1 supported group addresses from ets-export.xml/i)).toBeInTheDocument();
+
+      await waitFor(() => {
+        expect(api.updateConfig).toHaveBeenCalledWith(expect.objectContaining({
+          importedGroupAddressesFileName: 'ets-export.xml',
+          importedGroupAddresses: [expect.objectContaining({
+            address: '1/0/1',
+            name: 'Hallway Light',
+            functionType: 'switch',
+            supported: true,
+          })],
+        }));
+      });
     } finally {
       window.FileReader = originalFileReader;
     }


### PR DESCRIPTION
## Summary\n- persist imported ETS/group-address data in backend config\n- restore imported ETS address book + file name on reload/restart\n- add test coverage for persisted ETS imports\n\n## Verification\n- npm test ✅ (90/90)\n- npm run build ✅\n\nCloses #42