### PR TITLE
fix: persist imported ETS XML/group address data across restarts

### DIFF
--- a/knx-web-app/backend/server.js
+++ b/knx-web-app/backend/server.js
@@ -27,8 +27,35 @@ let config = {
   knxIp: '',
   knxPort: 3671,
   hue: { bridgeIp: '', apiKey: '' },
-  rooms: []
+  rooms: [],
+  importedGroupAddresses: [],
+  importedGroupAddressesFileName: ''
 };
+
+function normalizeImportedGroupAddresses(addresses) {
+  if (!Array.isArray(addresses)) return [];
+  return addresses
+    .filter((entry) => entry && typeof entry === 'object')
+    .map((entry) => ({
+      address: typeof entry.address === 'string' ? entry.address : '',
+      name: typeof entry.name === 'string' ? entry.name : '',
+      dpt: typeof entry.dpt === 'string' ? entry.dpt : '',
+      functionType: typeof entry.functionType === 'string' ? entry.functionType : '',
+      supported: entry.supported !== false,
+    }))
+    .filter((entry) => entry.address && entry.name);
+}
+
+function normalizeConfigShape(input) {
+  if (!input || typeof input !== 'object') return;
+  if (!input.knxPort) input.knxPort = 3671;
+  if (!input.hue) input.hue = { bridgeIp: '', apiKey: '' };
+  if (!Array.isArray(input.rooms)) input.rooms = [];
+  input.importedGroupAddresses = normalizeImportedGroupAddresses(input.importedGroupAddresses);
+  input.importedGroupAddressesFileName = typeof input.importedGroupAddressesFileName === 'string'
+    ? input.importedGroupAddressesFileName
+    : '';
+}
 
 function establishConnection() {
   if (config.knxIp) {
@@ -85,8 +112,7 @@ if (fs.existsSync(CONFIG_FILE)) {
   try {
     const data = fs.readFileSync(CONFIG_FILE, 'utf8');
     config = JSON.parse(data);
-    if (!config.knxPort) config.knxPort = 3671;
-    if (!config.hue) config.hue = { bridgeIp: '', apiKey: '' };
+    normalizeConfigShape(config);
     hueService.init(config.hue);
     establishConnection();
   } catch(e) {
@@ -95,6 +121,7 @@ if (fs.existsSync(CONFIG_FILE)) {
 }
 
 function saveConfig() {
+  normalizeConfigShape(config);
   fs.writeFileSync(CONFIG_FILE, JSON.stringify(config, null, 2));
 }
 
@@ -109,7 +136,7 @@ app.get('/api/config', (req, res) => {
 });
 
 app.post('/api/config', (req, res) => {
-  const { knxIp, knxPort, rooms } = req.body;
+  const { knxIp, knxPort, rooms, importedGroupAddresses, importedGroupAddressesFileName } = req.body;
   
   let shouldReconnect = false;
 
@@ -129,6 +156,16 @@ app.post('/api/config', (req, res) => {
   
   if (rooms !== undefined) {
     config.rooms = rooms;
+  }
+
+  if (importedGroupAddresses !== undefined) {
+    config.importedGroupAddresses = normalizeImportedGroupAddresses(importedGroupAddresses);
+  }
+
+  if (importedGroupAddressesFileName !== undefined) {
+    config.importedGroupAddressesFileName = typeof importedGroupAddressesFileName === 'string'
+      ? importedGroupAddressesFileName
+      : '';
   }
   
   saveConfig();

--- a/knx-web-app/frontend/src/Settings.jsx
+++ b/knx-web-app/frontend/src/Settings.jsx
@@ -600,6 +600,8 @@ export default function Settings({ config, fetchConfig, addToast, hueStatus, set
     setPort(config.knxPort || 3671);
     setRooms(migrateRooms(config.rooms || []));
     setHueBridgeIp(config.hue?.bridgeIp || '');
+    setGroupAddressBook(Array.isArray(config.importedGroupAddresses) ? config.importedGroupAddresses : []);
+    setGroupAddressFileName(config.importedGroupAddressesFileName || '');
   }, [config]);
   // Hue scene linking modal
   const [hueSceneModal, setHueSceneModal] = useState({ open: false, roomId: null, sceneId: null });
@@ -829,16 +831,31 @@ export default function Settings({ config, fetchConfig, addToast, hueStatus, set
     setGroupAddressModal({ open: false, roomId: null, title: 'Select Group Address', mode: 'any', target: null, allowUpload: false, helperText: '' });
   };
 
-  const importGroupAddresses = (addresses, fileName) => {
-    setGroupAddressBook(addresses);
-    setGroupAddressFileName(fileName);
-    addToast(`Imported ${addresses.length} group addresses`, 'success');
+  const importGroupAddresses = async (addresses, fileName) => {
+    try {
+      await updateConfig({
+        importedGroupAddresses: addresses,
+        importedGroupAddressesFileName: fileName,
+      });
+      setGroupAddressBook(addresses);
+      setGroupAddressFileName(fileName);
+      addToast(`Imported ${addresses.length} group addresses`, 'success');
+      fetchConfig();
+    } catch {
+      addToast('Failed to persist imported group addresses', 'error');
+    }
   };
 
-  const clearGroupAddresses = () => {
-    setGroupAddressBook([]);
-    setGroupAddressFileName('');
-    addToast('Imported group addresses cleared', 'success');
+  const clearGroupAddresses = async () => {
+    try {
+      await updateConfig({ importedGroupAddresses: [], importedGroupAddressesFileName: '' });
+      setGroupAddressBook([]);
+      setGroupAddressFileName('');
+      addToast('Imported group addresses cleared', 'success');
+      fetchConfig();
+    } catch {
+      addToast('Failed to clear imported group addresses', 'error');
+    }
   };
 
   const handleSelectGroupAddress = async (groupAddress) => {

--- a/knx-web-app/frontend/src/__tests__/Settings.test.jsx
+++ b/knx-web-app/frontend/src/__tests__/Settings.test.jsx
@@ -30,6 +30,8 @@ const BASE_CONFIG = {
   knxPort: 3671,
   hue: { bridgeIp: '', apiKey: '' },
   rooms: [],
+  importedGroupAddresses: [],
+  importedGroupAddressesFileName: '',
 };
 
 const CONFIG_WITH_ROOM = {
@@ -363,6 +365,58 @@ describe('Settings — ETS modal filtering', () => {
       });
 
       expect(addToast).toHaveBeenCalledWith('Added "Living Room - Blind Position" from ETS', 'success');
+    } finally {
+      window.FileReader = originalFileReader;
+    }
+  });
+
+  it('persists imported ETS addresses in config so they survive backend restarts', async () => {
+    const user = userEvent.setup();
+    renderSettings(CONFIG_WITH_ROOM);
+
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+      <KNX>
+        <GroupAddresses>
+          <GroupRange Name="House">
+            <GroupRange Name="Hallway">
+              <GroupAddress Id="ga-1" Address="1/0/1" Name="Hallway Light" DPTs="DPT 1.001" />
+            </GroupRange>
+          </GroupRange>
+        </GroupAddresses>
+      </KNX>`;
+
+    const originalFileReader = window.FileReader;
+    class MockFileReader {
+      constructor() {
+        this.onload = null;
+        this.onerror = null;
+      }
+      readAsText() {
+        this.onload?.({ target: { result: xml } });
+      }
+    }
+    window.FileReader = MockFileReader;
+
+    try {
+      await user.click(screen.getByRole('button', { name: /manage imported ets xml/i }));
+
+      const fileInput = document.querySelector('input[type="file"]');
+      expect(fileInput).not.toBeNull();
+      fireEvent.change(fileInput, { target: { files: [new File([xml], 'ets-export.xml', { type: 'text/xml' })] } });
+
+      expect(await screen.findByText(/imported 1 supported group addresses from ets-export.xml/i)).toBeInTheDocument();
+
+      await waitFor(() => {
+        expect(api.updateConfig).toHaveBeenCalledWith(expect.objectContaining({
+          importedGroupAddressesFileName: 'ets-export.xml',
+          importedGroupAddresses: [expect.objectContaining({
+            address: '1/0/1',
+            name: 'Hallway Light',
+            functionType: 'switch',
+            supported: true,
+          })],
+        }));
+      });
     } finally {
       window.FileReader = originalFileReader;
     }


### PR DESCRIPTION
$## Summary\n- persist imported ETS group addresses and source filename in backend config\n- reload imported ETS data into Settings after backend restart\n- cover the persistence flow with a frontend test\n\n## Verification\n- npm test -- --run src/__tests__/Settings.test.jsx\n\n## Context\nClean replacement for dirty PR #48. This PR contains only the issue #42 persistence fix on top of current `main`.