### PR TITLE
refactor/45-make-knx-web-app-the-repo-root

### DIFF
--- a/knx-web-app/.dockerignore
+++ b/knx-web-app/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.gitignore
+backend/node_modules
+frontend/node_modules
+frontend/dist
+data
+npm-debug.log

--- a/knx-web-app/Dockerfile
+++ b/knx-web-app/Dockerfile
@@ -1,0 +1,34 @@
+FROM node:20-bookworm-slim AS frontend-build
+
+WORKDIR /app/frontend
+
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
+
+COPY frontend/ ./
+RUN npm run build
+
+FROM node:20-bookworm-slim AS backend-deps
+
+WORKDIR /app/backend
+
+COPY backend/package.json backend/package-lock.json ./
+RUN npm ci --omit=dev
+
+FROM node:20-bookworm-slim AS runtime
+
+ENV NODE_ENV=production
+ENV PORT=3001
+ENV KNX_CONFIG_DIR=/app/data
+
+WORKDIR /app
+
+COPY --from=backend-deps /app/backend/node_modules ./backend/node_modules
+COPY backend/ ./backend/
+COPY --from=frontend-build /app/frontend/dist ./frontend/dist
+
+EXPOSE 3001
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 CMD ["node", "-e", "fetch(`http://127.0.0.1:${process.env.PORT || 3001}/api/config`).then((res) => process.exit(res.ok ? 0 : 1)).catch(() => process.exit(1))"]
+
+CMD ["node", "backend/server.js"]

--- a/knx-web-app/README.md
+++ b/knx-web-app/README.md
@@ -1,22 +1,23 @@
-# KNX Control
+# KNX Web App
 
-A local web application for controlling a KNX smart home system via a KNX IP interface. Supports KNX switches, blinds, lighting scenes, and Philips Hue lights — all in a single dashboard optimized for both desktop and mobile use.
+A local-first web UI for controlling KNX smart-home devices with optional Philips Hue bridge integration.
 
----
+## Features
 
-## Table of Contents
+- Configure KNX rooms and functions through a browser UI
+- Control switches, dimmers, blinds, and scenes
+- Optional Philips Hue bridge discovery and pairing
+- ETS XML import for faster group-address setup
+- Production frontend served by the backend on one port
 
-- [Architecture Overview](#architecture-overview)
-- [Prerequisites](#prerequisites)
-- [Installation](#installation)
-- [Starting the App](#starting-the-app)
-- [Configuration](#configuration)
-- [Philips Hue Integration](#philips-hue-integration)
-- [Using the Dashboard](#using-the-dashboard)
-- [Using the Settings](#using-the-settings)
-- [Project Structure](#project-structure)
-- [API Reference](#api-reference)
-- [Known Issues & Notes](#known-issues--notes)
+## Requirements
+
+1. A **KNX IP Interface** or **KNX IP Router**
+2. A machine on the **same local network** as the KNX bus gateway
+3. Node.js 20+ for native/manual installs
+4. _(Optional)_ A **Philips Hue Bridge** on the same local network
+
+> **Important:** The backend and the KNX interface must be on the **same local network**. KNX communication uses UDP multicast and does not work across network boundaries (e.g. VPN).
 
 ---
 
@@ -45,22 +46,18 @@ A local web application for controlling a KNX smart home system via a KNX IP int
 
 ---
 
-## Prerequisites
-
-Before running this app, you need:
-
-1. **Node.js** v18 or later — [nodejs.org](https://nodejs.org)
-2. **npm** (comes with Node.js)
-3. A **KNX IP Interface** (e.g. MDT SCN-IP000.03) connected to your local network
-4. _(Optional)_ A **Philips Hue Bridge** on the same local network
-
-> **Important:** The backend and the KNX interface must be on the **same local network**. KNX communication uses UDP multicast and does not work across network boundaries (e.g. VPN).
-
----
-
 ## Installation & Deployment
 
-## Installation & Upgrades
+You now have two supported ways to run the app in production:
+
+| Option | Best for | Why choose it |
+|------|------|------|
+| **Native installer (`install.sh`)** | Raspberry Pi or Debian/Ubuntu hosts that should behave like an appliance | Installs dependencies for you, registers a `systemd` service, starts on boot, and adds `knx-start` / `knx-stop` / `knx-update` commands |
+| **Docker (`compose.yaml`)** | Hosts that already use Docker and where you want a contained runtime | Keeps app dependencies isolated, makes upgrades predictable, and only requires Docker + Docker Compose |
+
+If you want the most "plug it in and forget it" setup on a Raspberry Pi, use the native installer. If you already manage services with Docker or want a clean rollback/rebuild path, use Docker.
+
+### Native Install & Upgrades
 
 We provide a script to securely install Node.js, npm, and the KNX Web App via a single command onto a Raspberry Pi, or any Debian-based Linux OS. This script can also be used to seamlessly upgrade an existing install when a new release is passed to the main branch.
 
@@ -78,7 +75,7 @@ This script will explain what it's about to do and pause to let you confirm. Und
 
 ---
 
-## 🛠️ Working with the background service (CLI)
+### Working with the background service (CLI)
 
 Because the app is registered on the OS level, you no longer need to keep a terminal running to keep your smart home alive. The installer also sets up several convenient global commands in your terminal:
 
@@ -103,6 +100,68 @@ sudo systemctl disable knx-web-app.service
 
 ---
 
+### Docker Deployment
+
+The Docker path is an additional deployment option. It uses the same production model as the native install: the backend serves the built frontend on **port `3001`**.
+
+#### What Docker exposes
+
+- **TCP `3001`**: Web UI, API, and Socket.IO traffic
+- **Outbound UDP `3671`**: Container talks from the app to your KNX IP interface
+- **Outbound HTTP on your LAN**: Container talks to the Philips Hue bridge
+
+You only need to publish **port `3001`** on the Docker host. KNX and Hue communication are outbound connections from the container to devices on your LAN.
+
+#### Quick start
+
+From the `knx-web-app` directory:
+
+```bash
+mkdir -p data
+docker compose up -d --build
+```
+
+Then open:
+
+- On the same machine: `http://localhost:3001`
+- From another device on your LAN: `http://<docker-host-ip>:3001`
+
+The app configuration is stored in `./data/config.json` on the host so it survives container rebuilds and upgrades.
+
+Useful commands:
+
+```bash
+docker compose logs -f
+docker compose ps
+docker compose pull
+docker compose up -d --build
+docker compose down
+```
+
+#### LAN access
+
+If the container is running on a Raspberry Pi, mini PC, or NAS, other devices on your local network should access it via the Docker host's LAN IP address, for example:
+
+```text
+http://192.168.1.50:3001
+```
+
+If that does not work, check the obvious network path first:
+
+1. The browser device and Docker host are on the same LAN/subnet.
+2. Port `3001/tcp` is not blocked by the host firewall.
+3. You are not trying to use `localhost` from another device. `localhost` only points to the device you are currently using.
+
+#### Common Docker gotchas
+
+- The app is still a **local-network** application. The container must be able to reach the KNX interface IP and Hue bridge IP directly from the Docker host's network.
+- Do **not** set `VITE_BACKEND_URL` for the normal Docker deployment. The frontend and backend are served together by the same container already.
+- Rebuilding the image does not erase settings as long as you keep the `./data` bind mount.
+- If you change the published port in `compose.yaml`, use the new host-side port in the browser URL. Example: `8080:3001` means browse to `http://<host-ip>:8080`.
+- If `docker compose up` fails because port `3001` is already in use, stop the native service or any old container first.
+
+---
+
 ## Development / Manual Setup
 
 If you prefer to run it manually or hack on the features, just clone the repo and launch the frontend and backend manually in two separate terminal tabs:
@@ -120,6 +179,7 @@ npm install
 npm run dev
 # Vite runs on :5173
 ```
+
 ```
 VITE v8.x.x  ready in xxx ms
 
@@ -130,216 +190,3 @@ VITE v8.x.x  ready in xxx ms
 > ```bash
 > pkill -f "vite"; pkill -f "node server.js"
 > ```
-
-### 3. Open in Browser (Development)
-
-Navigate to: **http://localhost:5173** (In production via the daemon, use `http://<Raspberry-IP>:3001`)
-
----
-
-## Configuration
-
-All configuration is saved automatically to `backend/config.json`. This file is created on first run.
-
-### KNX Interface
-
-1. Go to **Settings**
-2. Under **KNX Interface**, enter the IP address of your KNX IP interface and the port (default: `3671`)
-3. Click **Save** — the backend will immediately attempt to connect
-
-The connection status is shown in the header (green = connected, red = offline).
-
-### Rooms & Functions
-
-Rooms group your KNX devices for display on the dashboard. Each room can have:
-
-| Type | Description | DPT |
-|------|-------------|-----|
-| **Switch** | On/off toggle (e.g. lights, sockets) | DPT 1.001 |
-| **Blind** | Position slider 0–100% | DPT 5.001 |
-| **Scene** | Standalone scene trigger | DPT 17.001 |
-| **Hue Lamp** | Philips Hue light toggle | — |
-
----
-
-## Philips Hue Integration
-
-Hue lamps are controlled alongside KNX functions. Hue control uses **HTTP** to the local Hue Bridge (not the Hue cloud).
-
-### Pairing the Bridge
-
-1. Go to **Settings → Philips Hue**
-2. Click **Discover** — the app tries to auto-discover your bridge via `discovery.meethue.com`
-3. If discovery fails (common in isolated networks), click **Enter IP manually** and type the bridge IP (e.g. `192.168.1.65`)
-4. Press the **physical link button** on the top of your Hue Bridge
-5. Click **Pair** within 30 seconds
-
-Once paired, the bridge IP and API key are saved to `backend/config.json` under the `hue` key.
-
-### Adding Hue Lamps to Rooms
-
-1. Open **Settings** and find the desired room
-2. Click **+ Add Hue Lamp**
-3. Select a lamp from the popup list (fetched live from the bridge)
-4. The lamp appears as a purple-tinted card in the room with a **HUE** badge
-5. You can rename the lamp — the original bridge name is shown below the input
-
-### Hue Cards in the Dashboard
-
-Hue lamps render as toggle buttons alongside KNX functions. Clicking toggles the lamp on/off. The UI updates **immediately** (optimistic update) while the command is sent to the bridge in the background. If the command fails, the toggle reverts and an error toast appears.
-
----
-
-## Using the Dashboard
-
-The dashboard shows all configured rooms in a card grid.
-
-### Room Card Layout
-
-Each room card contains:
-- **Scene buttons** (colored pills) — one click triggers the KNX scene
-- **Shade scenes** (purple pills) — for blind presets
-- **Function widgets** — switches, blinds, and Hue lamps
-
-### Switch / Hue Toggle
-
-- Clicking the widget sends the command immediately (optimistic UI)
-- The toggle reflects the real state once WebSocket confirmation arrives
-- If KNX is offline, a toast error is shown
-
-### Blind Widget
-
-- Drag the slider to set the blind position (0% = open, 100% = closed)
-- The thin indicator bar on the right shows the **actual reported position** from the bus
-- Wall-switch movements update the indicator automatically without moving the slider
-
----
-
-## Using the Settings
-
-### KNX Interface Section
-- Set the IP and port of your KNX IP interface
-- Changes take effect immediately after clicking Save
-
-### Philips Hue Section
-- Shows pairing status and bridge IP
-- Unpair button removes all credentials from config
-
-### Rooms & Functions Section
-
-**Room management:**
-- Add a new room by typing a name and clicking **+ Add Room**
-- Rooms can be reordered with the ↑↓ arrows
-- Delete a room (and all its functions/scenes) with **Delete Room**
-
-**Scene configuration:**
-- Each room has a single **Scene GA** (group address) shared by all scenes
-- Add scenes with **+ Add Scene** (Light or Shade category)
-- Each scene has a number (1–64) and a label that appears as a pill on the dashboard
-- Scene numbers must match the scene numbers programmed in the KNX actuator
-
-**Function configuration (KNX):**
-- Each function needs:
-  - A **Name** (display label)
-  - A **Type** (Switch, Blind, Scene)
-  - An **Action GA** — the address written to when triggered
-  - _(Switch/Blind)_ A **Feedback GA** — the address the actuator reports status to
-  - _(Blind only)_ A **Moving GA** — signals when the blind is in motion
-
-**Function configuration (Hue):**
-- Only the display **Name** is editable
-- The original Hue lamp name from the bridge is shown for reference
-- No group addresses needed
-
-> **Important:** Click **Save Configuration** at the bottom of the Settings page to persist all changes. Changes are not autosaved.
-
----
-
-## Project Structure
-
-```
-knx-web-app/
-├── backend/
-│   ├── server.js          # Express API + Socket.IO server (port 3001)
-│   ├── knxService.js      # KNX IP connection & group address handling
-│   ├── hueService.js      # Philips Hue bridge discovery, pairing, control
-│   ├── config.json        # Runtime config (auto-created, not in git)
-│   └── package.json
-│
-└── frontend/
-    ├── src/
-    │   ├── App.jsx         # Root component: socket setup, global state
-    │   ├── Dashboard.jsx   # Dashboard view: room cards, switches, blinds
-    │   ├── Settings.jsx    # Settings view: rooms, functions, Hue setup
-    │   ├── configApi.js    # All fetch calls to the backend REST API
-    │   ├── index.css       # All styles (dark theme, responsive)
-    │   └── main.jsx        # React entry point
-    ├── index.html
-    └── package.json
-```
-
----
-
-## API Reference
-
-All endpoints are provided by the backend service (default port `3001`).
-
-### Config
-
-| Method | Path | Description |
-|--------|------|-------------|
-| `GET` | `/api/config` | Returns full application config (rooms, IP, Hue) |
-| `POST` | `/api/config` | Saves config (partial updates supported) |
-
-### KNX
-
-| Method | Path | Body | Description |
-|--------|------|------|-------------|
-| `POST` | `/api/action` | `{ groupAddress, type, value, sceneNumber }` | Send a value to a KNX group address |
-
-### Philips Hue
-
-| Method | Path | Body | Description |
-|--------|------|------|-------------|
-| `POST` | `/api/hue/discover` | — | Auto-discover bridge via meethue.com |
-| `POST` | `/api/hue/pair` | `{ bridgeIp }` | Pair with bridge at given IP (user must press link button first) |
-| `POST` | `/api/hue/unpair` | — | Remove Hue credentials from config |
-| `GET` | `/api/hue/lights` | — | List all lights from paired bridge |
-| `POST` | `/api/hue/action` | `{ lightId, on }` | Turn a light on or off |
-
-### WebSocket Events (Socket.IO)
-
-The backend emits the following events to all connected clients:
-
-| Event | Payload | Description |
-|-------|---------|-------------|
-| `knx_status` | `{ connected, msg }` | KNX connection state change |
-| `knx_initial_states` | `{ [groupAddress]: value }` | Full state snapshot on connect |
-| `knx_state_update` | `{ groupAddress, value }` | Single GA state change from bus |
-| `knx_error` | `{ msg }` | KNX error message |
-| `hue_status` | `{ paired, bridgeIp }` | Hue pairing state change |
-| `hue_states` | `{ [hue_<id>]: boolean }` | Full Hue state snapshot (polled every 5s) |
-| `hue_state_update` | `{ lightId, on }` | Single Hue light state change (after action) |
-
----
-
-## Known Issues & Notes
-
-### ⚠️ `socket={io(...)}` in JSX causes infinite re-renders
-Never pass `io(...)` as a JSX prop directly. Socket connections must only be created inside `useEffect`. This was a regression that caused the app to hang on load.
-
-### ⚠️ Port conflicts when restarting
-If Vite starts on port 5174 instead of 5173, a stale process is occupying the port. Fix:
-```bash
-pkill -f "vite"; pkill -f "node server.js"
-```
-Then restart both servers.
-
-### ℹ️ Hue Bridge uses HTTP (not HTTPS)
-The backend communicates with the Hue Bridge via **HTTP** on the local network. HTTPS was intentionally disabled because the bridge uses a self-signed certificate which causes Node.js `fetch` to reject the connection.
-
-### ℹ️ Optimistic UI for toggles
-Switch and Hue toggles update instantly in the UI before the backend confirms the change. If the action fails, the UI reverts and shows an error toast.
-
-### ℹ️ KNX scene numbers are 0-indexed on the bus
-The app automatically subtracts 1 from the scene number you enter (e.g. scene `1` → bus value `0`). This is the KNX DPT 17.001 standard.

--- a/knx-web-app/compose.yaml
+++ b/knx-web-app/compose.yaml
@@ -1,0 +1,14 @@
+services:
+  knx-web-app:
+    build:
+      context: .
+    container_name: knx-web-app
+    ports:
+      - "3001:3001"
+    environment:
+      PORT: "3001"
+      KNX_CONFIG_DIR: /app/data
+    volumes:
+      - ./data:/app/data
+    restart: unless-stopped
+    init: true


### PR DESCRIPTION
## Summary\n- move the app from  to the repository root\n- update workflow, README, and install references to the new root layout\n- keep frontend/backend commands working from the flattened structure\n\n## Verification\n- frontend npm test ✅ (90/90)\n- frontend npm run build ✅\n- backend npm test ✅ (82/82)\n\nCloses #45